### PR TITLE
Updated nuget dependencies

### DIFF
--- a/Setup/Setup.csproj
+++ b/Setup/Setup.csproj
@@ -19,12 +19,12 @@
     <PackageReference Include="HtmlSanitizer" Version="8.0.645" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.15" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="6.0.15" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.3">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.15">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -33,7 +33,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.TypeScript.MSBuild" Version="5.0.2">
+    <PackageReference Include="Microsoft.TypeScript.MSBuild" Version="5.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/SetupTest/SetupTest.csproj
+++ b/SetupTest/SetupTest.csproj
@@ -9,12 +9,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
-    <PackageReference Include="coverlet.collector" Version="3.1.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.6.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/SetupTests/SetupTests.csproj
+++ b/SetupTests/SetupTests.csproj
@@ -9,10 +9,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
-    <PackageReference Include="coverlet.collector" Version="3.1.2" />
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Project: Setup/Setup.csproj 
### Merging this PR will update the following dependencies
- Microsoft.EntityFrameworkCore 7.0.3 -> 7.0.4
- Microsoft.EntityFrameworkCore.Design 7.0.3 -> 7.0.4
- Microsoft.EntityFrameworkCore.SqlServer 7.0.3 -> 7.0.4
- Microsoft.TypeScript.MSBuild 5.0.2 -> 5.0.3

### Version updates outside of current version limit
- Microsoft.AspNetCore.Identity.EntityFrameworkCore 6.0.15 -> 7.0.4
- Microsoft.AspNetCore.Identity.UI 6.0.15 -> 7.0.4
- Microsoft.EntityFrameworkCore.Tools 6.0.15 -> 7.0.4
- Microsoft.VisualStudio.Web.CodeGeneration.Design 6.0.13 -> 7.0.5

Please update these manually or change version range.
# Project: SetupTest/SetupTest.csproj 
### Merging this PR will update the following dependencies
- coverlet.collector 3.1.2 -> 3.2.0
- Microsoft.NET.Test.Sdk 17.3.2 -> 17.5.0
- NUnit.Analyzers 3.3.0 -> 3.6.1
- NUnit3TestAdapter 4.2.1 -> 4.4.2

After merging this PR all dependencies that are not ignored will be updated to the latest version.
# Project: SetupTests/SetupTests.csproj 
### Merging this PR will update the following dependencies
- coverlet.collector 3.1.2 -> 3.2.0
- Microsoft.NET.Test.Sdk 17.3.2 -> 17.5.0

### Version updates outside of current version limit
- MSTest.TestAdapter 2.2.10 -> 3.0.2
- MSTest.TestFramework 2.2.10 -> 3.0.2

Please update these manually or change version range.